### PR TITLE
Disable configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,6 @@ org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dk
 org.gradle.configureondemand=true
 org.gradle.parallel=true
 org.gradle.daemon=true
-org.gradle.configuration-cache=true
+# Publishing releases to Maven Central is not supported yet with configuration caching
+# enabled, because of this missing Gradle feature: https://github.com/gradle/gradle/issues/22779
+# org.gradle.configuration-cache=true


### PR DESCRIPTION
Publishing releases to Maven Central is not supported yet with configuration caching enabled, because of this missing Gradle feature: https://github.com/gradle/gradle/issues/22779